### PR TITLE
Repl completion

### DIFF
--- a/extensions/repl.js
+++ b/extensions/repl.js
@@ -26,6 +26,14 @@ bind_cr = function(){
     lastLastLength = buffer.length;
 }
 
+function complete_globals(text)
+{
+    var glob = context.eval("(function(){ return this; })();");  // global object
+    var properties = Object.getOwnPropertyNames(glob);
+    completions = properties;
+    completions = completions.filter(function(s) { return s.indexOf(text) == 0; });
+}
+
 function complete_class_field(klass, klass_part, field_part)
 {
     var properties = Object.getOwnPropertyNames(klass);
@@ -36,9 +44,9 @@ function complete_class_field(klass, klass_part, field_part)
 
 function complete_object_field(obj, obj_part, field_part)
 {
-    var klass = obj.constructor;  
     var properties = Object.getOwnPropertyNames(obj);
-    var methods = Object.getOwnPropertyNames(klass.prototype); // there's also Object.getPrototypeOf()
+//    var methods = Object.getOwnPropertyNames(obj.constructor.prototype);
+    var methods = Object.getOwnPropertyNames(Object.getPrototypeOf(obj));  // better (eg imports.os)
     completions = properties.concat(methods);
     completions = completions.filter(function(s) { return s.indexOf(field_part) == 0; });
     completions = completions.map(function(s){ return obj_part + '.' + s });    
@@ -48,6 +56,12 @@ function complete_parse(text)
 {
     try
     {
+	if (text.indexOf('.') == -1)
+	{
+	    complete_globals(text);
+	    return;
+	}
+	
 	var a = text.split('.');    
 	var field_part = a.pop();  // first letters of field to complete
 	var obj_part = a.join('.');

--- a/extensions/repl.js
+++ b/extensions/repl.js
@@ -26,27 +26,45 @@ bind_cr = function(){
     lastLastLength = buffer.length;
 }
 
+function get_props_v1(obj)	// enumerable props only, not good for methods (eg String)
+{
+    var a = [];
+    for (var i in obj)
+	a.push(i);
+    return a;
+}
+
+function get_props_v2(obj)	// both enum and non enum, but misses inherited stuff (eg GtkWindow.show)
+{   return Object.getOwnPropertyNames(obj);   }
+
+function get_props(obj)		// Get all object properties
+{
+    var unique = function(value, index, self)
+    {  return self.indexOf(value) === index;   };
+    
+    var a = get_props_v1(obj).concat(get_props_v2(obj));
+    return a.filter(unique);
+}
+
 function complete_globals(text)
 {
     var glob = context.eval("(function(){ return this; })();");  // global object
-    var properties = Object.getOwnPropertyNames(glob);
-    completions = properties;
+    completions = get_props(glob);
     completions = completions.filter(function(s) { return s.indexOf(text) == 0; });
 }
 
 function complete_class_field(klass, klass_part, field_part)
 {
-    var properties = Object.getOwnPropertyNames(klass);
-    completions = properties;
+    completions = get_props(klass);
     completions = completions.filter(function(s) { return s.indexOf(field_part) == 0; });
     completions = completions.map(function(s){ return klass_part + '.' + s });
 }
 
 function complete_object_field(obj, obj_part, field_part)
 {
-    var properties = Object.getOwnPropertyNames(obj);
-//    var methods = Object.getOwnPropertyNames(obj.constructor.prototype);
-    var methods = Object.getOwnPropertyNames(Object.getPrototypeOf(obj));  // better (eg imports.os)
+    var properties = get_props(obj);
+//    var methods = get_props(obj.constructor.prototype);
+    var methods = get_props(Object.getPrototypeOf(obj));  // better (eg imports.os)
     completions = properties.concat(methods);
     completions = completions.filter(function(s) { return s.indexOf(field_part) == 0; });
     completions = completions.map(function(s){ return obj_part + '.' + s });    

--- a/extensions/repl.js
+++ b/extensions/repl.js
@@ -26,11 +26,52 @@ bind_cr = function(){
     lastLastLength = buffer.length;
 }
 
+function complete_obj_get_obj(text)
+{
+    try
+    {
+	var a = text.split('.');    a.pop();
+	var obj_str = a.join('.');
+	var obj = context.eval(obj_str);
+	return (typeof obj == "object" ? obj : null);
+    }
+    catch (e)
+    { return null; }
+}
+
+var completions = [];
+
+function complete(text, state)
+{
+//    os.write(1, "text: '" + text + "'\n");
+
+    if (!state) // new word to complete
+    {
+	var obj = complete_obj_get_obj(text);
+	if (!obj)
+	    return null;
+	var a = text.split('.');
+	var field_part = a.pop();  // first letters of field to complete
+	var obj_part = a.join('.');
+	var klass = obj.constructor;
+	var properties = Object.getOwnPropertyNames(obj);
+	var methods = Object.getOwnPropertyNames(klass.prototype);
+	completions = properties.concat(methods);
+	completions = completions.filter(function(s) { return s.indexOf(field_part) == 0; });
+	completions = completions.map(function(s){ return obj_part + '.' + s });
+    }
+
+    if (state == completions.length)
+	return null;
+    return completions[state];
+}
+
 readline.bind('\n', bind_cr);
 readline.bind('\r', bind_cr);
-readline.bind('\t', function(){
-    readline.insert("\t");
-});
+
+readline.completion_entry(complete);
+//readline.bind('\t', function(){ readline.insert("\t"); });
+
 
 //var re = /[^=<>*-^/]=[^=<>*-^/]\(*\s*(new\s*)?[^:punct:]|'|"+\)*$/
 


### PR DESCRIPTION
Hi,

Here's a branch I wrote a while ago which adds completion to the interpreter (kind of like in the firebug / chrome  developer tools consoles).

It's far from perfect but pretty neat to use already. The interpreter completes globals, classes and object properties / methods now, so you can for example find out string methods with:

```
> var s = new String("");
> s.<TAB>
```

Or find stuff in the os module with:

```
> os=imports.os
> os.<TAB>
```

I added an entry in the readline module to register the completion handler, hopefully I got the closure part right. 
